### PR TITLE
[9.x] Support more hasing algorithms for hash

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -162,14 +162,15 @@ class Filesystem
     }
 
     /**
-     * Get the MD5 hash of the file at the given path.
+     * Get the hash of the file at the given path.
      *
      * @param  string  $path
+     * @param  string  $algo
      * @return string
      */
-    public function hash($path)
+    public function hash($path, $algo = 'md5')
     {
-        return md5_file($path);
+        return hash_file($algo, $path);
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -571,6 +571,7 @@ class FilesystemTest extends TestCase
         file_put_contents(self::$tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash(self::$tempDir.'/foo.txt'));
+        $this->assertSame('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha256'));
     }
 
     /**


### PR DESCRIPTION
This PR add support for using other hash algorithms with the hash method in filesystem because md5 has collisions and is not secure.

Existing code is not affected because when the second parameter is not specified, it will uses md5 as expected.